### PR TITLE
[#1572] experimental implementation

### DIFF
--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -70,16 +70,16 @@ public class RepoConfiguration {
         this.isShallowCloningPerformed = isShallowCloningPerformed;
         this.isFindingPreviousAuthorsPerformed = isFindingPreviousAuthorsPerformed;
 
-        String organization = location.getOrganization();
+        String[] organization = location.getPath();
         String repoName = location.getRepoName();
         displayName = repoName + "[" + branch + "]";
         outputFolderName = repoName + "_" + branch;
         repoFolderName = repoName;
 
         if (organization != null) {
-            repoFolderName = organization + "_" + repoFolderName;
-            displayName = organization + "/" + displayName;
-            outputFolderName = organization + "_" + outputFolderName;
+            repoFolderName = String.join("_", organization) + "_" + repoFolderName;
+            displayName = String.join("/", organization)+ "/" + displayName;
+            outputFolderName = String.join("_", organization) + "_" + outputFolderName;
         }
     }
 
@@ -552,8 +552,8 @@ public class RepoConfiguration {
         return location;
     }
 
-    public String getOrganization() {
-        return location.getOrganization();
+    public String[] getPath() {
+        return location.getPath();
     }
 
     public boolean isStandaloneConfigIgnored() {

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -76,10 +76,10 @@ public class RepoConfiguration {
         outputFolderName = repoName + "_" + branch;
         repoFolderName = repoName;
 
-        if (organization != null) {
-            repoFolderName = String.join("_", organization) + "_" + repoFolderName;
-            displayName = String.join("/", organization) + "/" + displayName;
-            outputFolderName = String.join("_", organization) + "_" + outputFolderName;
+        if (!organization.isEmpty()) {
+            repoFolderName = organization + "_" + repoFolderName;
+            displayName = organization + "/" + displayName;
+            outputFolderName = organization + "_" + outputFolderName;
         }
     }
 

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -70,7 +70,7 @@ public class RepoConfiguration {
         this.isShallowCloningPerformed = isShallowCloningPerformed;
         this.isFindingPreviousAuthorsPerformed = isFindingPreviousAuthorsPerformed;
 
-        String organization = location.getPath();
+        String organization = location.getOrganization();
         String repoName = location.getRepoName();
         displayName = repoName + "[" + branch + "]";
         outputFolderName = repoName + "_" + branch;
@@ -553,7 +553,7 @@ public class RepoConfiguration {
     }
 
     public String getPath() {
-        return location.getPath();
+        return location.getOrganization();
     }
 
     public boolean isStandaloneConfigIgnored() {

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -70,7 +70,7 @@ public class RepoConfiguration {
         this.isShallowCloningPerformed = isShallowCloningPerformed;
         this.isFindingPreviousAuthorsPerformed = isFindingPreviousAuthorsPerformed;
 
-        String[] organization = location.getPath();
+        String organization = location.getPath();
         String repoName = location.getRepoName();
         displayName = repoName + "[" + branch + "]";
         outputFolderName = repoName + "_" + branch;
@@ -552,7 +552,7 @@ public class RepoConfiguration {
         return location;
     }
 
-    public String[] getPath() {
+    public String getPath() {
         return location.getPath();
     }
 

--- a/src/main/java/reposense/model/RepoConfiguration.java
+++ b/src/main/java/reposense/model/RepoConfiguration.java
@@ -78,7 +78,7 @@ public class RepoConfiguration {
 
         if (organization != null) {
             repoFolderName = String.join("_", organization) + "_" + repoFolderName;
-            displayName = String.join("/", organization)+ "/" + displayName;
+            displayName = String.join("/", organization) + "/" + displayName;
             outputFolderName = String.join("_", organization) + "_" + outputFolderName;
         }
     }

--- a/src/main/java/reposense/model/RepoLocation.java
+++ b/src/main/java/reposense/model/RepoLocation.java
@@ -33,7 +33,10 @@ public class RepoLocation {
         }
 
         this.location = location;
-        if (isLocalRepo(location)) {
+        if (location.isEmpty()) {
+            repoName = "";
+            path = new String[0];
+        } else if (isLocalRepo(location)) {
             Matcher localRepoMatcher = LOCAL_REPOSITORY_LOCATION_PATTERN.matcher(location);
 
             if (!localRepoMatcher.matches()) {

--- a/src/main/java/reposense/model/RepoLocation.java
+++ b/src/main/java/reposense/model/RepoLocation.java
@@ -22,7 +22,7 @@ public class RepoLocation {
 
     private final String location;
     private final String repoName;
-    private final String[] path;
+    private final String organization;
 
     /**
      * @throws InvalidLocationException if {@code location} cannot be represented by a {@code URL} or {@code Path}.
@@ -35,7 +35,7 @@ public class RepoLocation {
         this.location = location;
         if (location.isEmpty()) {
             repoName = "";
-            path = new String[0];
+            organization = "";
         } else if (isLocalRepo(location)) {
             Matcher localRepoMatcher = LOCAL_REPOSITORY_LOCATION_PATTERN.matcher(location);
 
@@ -44,7 +44,7 @@ public class RepoLocation {
             }
 
             repoName = localRepoMatcher.group("repoName");
-            path = localRepoMatcher.group("path").split("/");
+            organization = localRepoMatcher.group("path").replaceAll("/", "-");
         } else {
             Matcher remoteRepoMatcher = GIT_REPOSITORY_LOCATION_PATTERN.matcher(location);
             Matcher sshRepoMatcher = SCP_LIKE_SSH_REPOSITORY_LOCATION_PATTERN.matcher(location);
@@ -56,7 +56,7 @@ public class RepoLocation {
 
             Matcher actualMatcher = remoteRepoMatcher.matches() ? remoteRepoMatcher : sshRepoMatcher;
             repoName = actualMatcher.group("repoName");
-            path = actualMatcher.group("path").split("/");
+            organization = actualMatcher.group("path").replaceAll("/", "-");
         }
     }
 
@@ -68,8 +68,8 @@ public class RepoLocation {
         return repoName;
     }
 
-    public String[] getPath() {
-        return path;
+    public String getPath() {
+        return organization;
     }
 
     /**

--- a/src/main/java/reposense/model/RepoLocation.java
+++ b/src/main/java/reposense/model/RepoLocation.java
@@ -14,11 +14,11 @@ public class RepoLocation {
     private static final String MESSAGE_INVALID_LOCATION = "%s is an invalid location.";
 
     private static final Pattern GIT_REPOSITORY_LOCATION_PATTERN =
-            Pattern.compile("^(ssh|git|https?)://[^/]*?/(?<path>.*?)/?(?<repoName>[^/]+?)(\\.git)?/?$");
+            Pattern.compile("^(ssh|git|https?|ftps?)://[^/]*?/(?<path>.*?)/?(?<repoName>[^/]+?)(/?\\.git)?/?$");
     private static final Pattern SCP_LIKE_SSH_REPOSITORY_LOCATION_PATTERN =
-            Pattern.compile("^.*?:(?<path>.*?)/?(?<repoName>[^/]+?)(\\.git)?/?$");
+            Pattern.compile("^.*?:(?<path>[^/]??.*?)/?(?<repoName>[^/]+?)(\\.git)?/?$");
     private static final Pattern LOCAL_REPOSITORY_LOCATION_PATTERN =
-            Pattern.compile("^(file://)?/?(?<path>.*?)/?(?<repoName>[^/]+?)(\\.git)?/?$");
+            Pattern.compile("^(file://)?(?<path>.*?)[/\\\\]?(?<repoName>[^/\\\\]+?)([/\\\\]?\\.git)?[/\\\\]?$");
 
     private final String location;
     private final String repoName;
@@ -44,7 +44,8 @@ public class RepoLocation {
             }
 
             repoName = localRepoMatcher.group("repoName");
-            organization = localRepoMatcher.group("path").replaceAll("/", "-");
+            String fileSeparator = SystemUtil.isWindows() ? "[/\\\\]" : "/";
+            organization = localRepoMatcher.group("path").replaceAll(fileSeparator, "-");
         } else {
             Matcher remoteRepoMatcher = GIT_REPOSITORY_LOCATION_PATTERN.matcher(location);
             Matcher sshRepoMatcher = SCP_LIKE_SSH_REPOSITORY_LOCATION_PATTERN.matcher(location);
@@ -68,7 +69,7 @@ public class RepoLocation {
         return repoName;
     }
 
-    public String getPath() {
+    public String getOrganization() {
         return organization;
     }
 

--- a/src/main/java/reposense/model/RepoLocation.java
+++ b/src/main/java/reposense/model/RepoLocation.java
@@ -19,7 +19,7 @@ public class RepoLocation {
     private static final String GIT_LINK_SUFFIX = ".git";
     private static final String MESSAGE_INVALID_LOCATION = "%s is an invalid location.";
     private static final Pattern GIT_REPOSITORY_LOCATION_PATTERN =
-            Pattern.compile("^https?://github.com/(?<org>.+?)/(?<repoName>.+?)\\.git$");
+            Pattern.compile("^.*/(?<org>.+?)/(?<repoName>.+?)\\.git$");
 
     private final String location;
     private final String repoName;
@@ -32,15 +32,16 @@ public class RepoLocation {
         if (SystemUtil.isWindows()) {
             location = StringsUtil.removeTrailingBackslash(location);
         }
-        verifyLocation(location);
         this.location = location;
         Matcher matcher = GIT_REPOSITORY_LOCATION_PATTERN.matcher(location);
 
-        if (matcher.matches()) {
+        if (isLocalRepo(location)) {
+            repoName = Paths.get(location).getFileName().toString().replace(GIT_LINK_SUFFIX, "");
+        } else if (matcher.matches()) {
             organization = matcher.group("org");
             repoName = matcher.group("repoName");
         } else {
-            repoName = Paths.get(location).getFileName().toString().replace(GIT_LINK_SUFFIX, "");
+            repoName = "UNABLE_TO_DETERMINE";
         }
     }
 
@@ -56,28 +57,23 @@ public class RepoLocation {
         return organization;
     }
 
-    /**
-     * Verifies {@code location} can be presented as a {@code URL} or {@code Path}.
-     * @throws InvalidLocationException if otherwise.
-     */
-    private void verifyLocation(String location) throws InvalidLocationException {
-        boolean isValidPathLocation = false;
-        boolean isValidGitUrl = false;
-
-        try {
-            Path pathLocation = Paths.get(location);
-            isValidPathLocation = Files.exists(pathLocation);
-        } catch (InvalidPathException ipe) {
-            // Ignore exception
+    private boolean isLocalRepo(String repoArgument) {
+        boolean containsColon = repoArgument.contains(":");
+        if (!containsColon) {
+            return true;
         }
 
-        Matcher matcher = GIT_REPOSITORY_LOCATION_PATTERN.matcher(location);
-        isValidGitUrl = matcher.matches();
-
-        if (!isValidPathLocation && !isValidGitUrl) {
-            ErrorSummary.getInstance().addErrorMessage(location, String.format(MESSAGE_INVALID_LOCATION, location));
-            throw new InvalidLocationException(String.format(MESSAGE_INVALID_LOCATION, location));
+        boolean hasSlashBeforeFirstColon = repoArgument.split(":", 2)[0].contains("/");
+        if (hasSlashBeforeFirstColon) {
+            return true;
         }
+
+        boolean isURLFileType = repoArgument.split(":", 2)[0].equals("file");
+        if (isURLFileType) {
+            return true;
+        }
+
+        return false;
     }
 
 

--- a/src/main/java/reposense/model/RepoLocation.java
+++ b/src/main/java/reposense/model/RepoLocation.java
@@ -1,14 +1,10 @@
 package reposense.model;
 
-import java.nio.file.Files;
-import java.nio.file.InvalidPathException;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import reposense.parser.InvalidLocationException;
-import reposense.report.ErrorSummary;
 import reposense.util.StringsUtil;
 import reposense.util.SystemUtil;
 
@@ -17,7 +13,6 @@ import reposense.util.SystemUtil;
  */
 public class RepoLocation {
     private static final String GIT_LINK_SUFFIX = ".git";
-    private static final String MESSAGE_INVALID_LOCATION = "%s is an invalid location.";
     private static final Pattern GIT_REPOSITORY_LOCATION_PATTERN =
             Pattern.compile("^.*/(?<org>.+?)/(?<repoName>.+?)\\.git$");
 
@@ -57,6 +52,9 @@ public class RepoLocation {
         return organization;
     }
 
+    /**
+     * Returns true if {@code repoArgument} is a valid local repository argument.
+     */
     private boolean isLocalRepo(String repoArgument) {
         boolean containsColon = repoArgument.contains(":");
         if (!containsColon) {
@@ -68,8 +66,8 @@ public class RepoLocation {
             return true;
         }
 
-        boolean isURLFileType = repoArgument.split(":", 2)[0].equals("file");
-        if (isURLFileType) {
+        boolean isUrlFileType = repoArgument.split(":", 2)[0].equals("file");
+        if (isUrlFileType) {
             return true;
         }
 

--- a/src/main/java/reposense/model/RepoLocation.java
+++ b/src/main/java/reposense/model/RepoLocation.java
@@ -1,6 +1,5 @@
 package reposense.model;
 
-import java.nio.file.Paths;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -12,8 +11,8 @@ import reposense.util.SystemUtil;
  * Represents a repository location.
  */
 public class RepoLocation {
-    private static final String GIT_LINK_SUFFIX = ".git";
     private static final String MESSAGE_INVALID_LOCATION = "%s is an invalid location.";
+
     private static final Pattern GIT_REPOSITORY_LOCATION_PATTERN =
             Pattern.compile("^(ssh|git|https?)://[^/]*?/(?<path>.*?)/?(?<repoName>[^/]+?)(\\.git)?/?$");
     private static final Pattern SCP_LIKE_SSH_REPOSITORY_LOCATION_PATTERN =
@@ -23,7 +22,7 @@ public class RepoLocation {
 
     private final String location;
     private final String repoName;
-    private final String path;
+    private final String[] path;
 
     /**
      * @throws InvalidLocationException if {@code location} cannot be represented by a {@code URL} or {@code Path}.
@@ -42,7 +41,7 @@ public class RepoLocation {
             }
 
             repoName = localRepoMatcher.group("repoName");
-            path = localRepoMatcher.group("path").replaceAll("/", "-");
+            path = localRepoMatcher.group("path").split("/");
         } else {
             Matcher remoteRepoMatcher = GIT_REPOSITORY_LOCATION_PATTERN.matcher(location);
             Matcher sshRepoMatcher = SCP_LIKE_SSH_REPOSITORY_LOCATION_PATTERN.matcher(location);
@@ -54,7 +53,7 @@ public class RepoLocation {
 
             Matcher actualMatcher = remoteRepoMatcher.matches() ? remoteRepoMatcher : sshRepoMatcher;
             repoName = actualMatcher.group("repoName");
-            path = actualMatcher.group("path").replaceAll("/", "-");
+            path = actualMatcher.group("path").split("/");
         }
     }
 
@@ -66,7 +65,7 @@ public class RepoLocation {
         return repoName;
     }
 
-    public String getOrganization() {
+    public String[] getPath() {
         return path;
     }
 

--- a/src/main/java/reposense/model/RepoLocation.java
+++ b/src/main/java/reposense/model/RepoLocation.java
@@ -14,11 +14,13 @@ import reposense.util.SystemUtil;
 public class RepoLocation {
     private static final String GIT_LINK_SUFFIX = ".git";
     private static final Pattern GIT_REPOSITORY_LOCATION_PATTERN =
-            Pattern.compile("^.*/(?<org>.+?)/(?<repoName>.+?)\\.git$");
+            Pattern.compile("^(ssh|git|https?)://.*?/(?<path>.+)/(?<repoName>.+?)(\\.git)?$");
+    private static final Pattern SCP_LIKE_SSH_REPOSITORY_LOCATION_PATTERN =
+            Pattern.compile("^.*?:(?<path>.+)/(?<repoName>.+?)(\\.git)?$");
 
     private final String location;
     private final String repoName;
-    private String organization;
+    private String path;
 
     /**
      * @throws InvalidLocationException if {@code location} cannot be represented by a {@code URL} or {@code Path}.
@@ -33,7 +35,7 @@ public class RepoLocation {
         if (isLocalRepo(location)) {
             repoName = Paths.get(location).getFileName().toString().replace(GIT_LINK_SUFFIX, "");
         } else if (matcher.matches()) {
-            organization = matcher.group("org");
+            path = matcher.group("path");
             repoName = matcher.group("repoName");
         } else {
             repoName = "UNABLE_TO_DETERMINE";
@@ -49,11 +51,15 @@ public class RepoLocation {
     }
 
     public String getOrganization() {
-        return organization;
+        return path;
     }
 
     /**
      * Returns true if {@code repoArgument} is a valid local repository argument.
+     * This implementation follows directly from the {@code git clone}
+     * <a href="https://git-scm.com/docs/git-clone#_git_urls">specification</a>.
+     *
+     * Throws an in
      */
     private boolean isLocalRepo(String repoArgument) {
         boolean containsColon = repoArgument.contains(":");

--- a/src/test/java/reposense/model/RepoConfigurationTest.java
+++ b/src/test/java/reposense/model/RepoConfigurationTest.java
@@ -58,7 +58,6 @@ public class RepoConfigurationTest {
     private static final String TEST_REPO_DELTA = "https://github.com/reposense/testrepo-Delta.git";
     private static final String TEST_REPO_MINIMAL_STANDALONE_CONFIG =
             "https://github.com/reposense/testrepo-minimalstandaloneconfig.git";
-    private static final String TEST_REPO_INVALID_LOCATION = "ftp://github.com/reposense/testrepo-Delta.git";
 
     private static final Author FIRST_AUTHOR = new Author("lithiumlkid");
     private static final Author SECOND_AUTHOR = new Author("codeeong");

--- a/src/test/java/reposense/model/RepoConfigurationTest.java
+++ b/src/test/java/reposense/model/RepoConfigurationTest.java
@@ -704,17 +704,4 @@ public class RepoConfigurationTest {
 
         TestUtil.compareRepoConfig(expectedConfig, actualConfig);
     }
-
-    @Test
-    public void repoConfig_withInvalidLocation_success() throws Exception {
-        String formats = String.join(" ", CLI_FORMATS);
-        String input = new InputBuilder().addRepos(TEST_REPO_BETA, TEST_REPO_DELTA, TEST_REPO_INVALID_LOCATION)
-                .addFormats(formats)
-                .addIgnoreStandaloneConfig()
-                .build();
-        CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
-        List<RepoConfiguration> actualConfigs = RepoSense.getRepoConfigurations((LocationsCliArguments) cliArguments);
-
-        Assert.assertEquals(2, actualConfigs.size());
-    }
 }

--- a/src/test/java/reposense/model/RepoLocationTest.java
+++ b/src/test/java/reposense/model/RepoLocationTest.java
@@ -1,12 +1,122 @@
 package reposense.model;
 
+import org.junit.Assert;
 import org.junit.Test;
+import reposense.parser.InvalidLocationException;
+import reposense.util.AssertUtil;
 
 public class RepoLocationTest {
+
+    private static final String LOCAL_REPO_LOCATION_VALID_WITHOUT_DOT_GIT_ONE = "path/to/repo/";
+    private static final String LOCAL_REPO_LOCATION_VALID_WITHOUT_DOT_GIT_TWO = "../path/to/repo";
+    private static final String LOCAL_REPO_LOCATION_VALID_WITHOUT_DOT_GIT_THREE = "file://path/to/repo";
+    private static final String LOCAL_REPO_LOCATION_VALID_WITH_DOT_GIT_ONE = "path/to/repo/.git";
+    private static final String LOCAL_REPO_LOCATION_VALID_WITH_DOT_GIT_TWO = "file://path/to/repo/.git";
+
+    private static final String LOCAL_REPO_LOCATION_WINDOWS_VALID_WITHOUT_DOT_GIT_ONE = "path\\to\\repo\\";
+    private static final String LOCAL_REPO_LOCATION_WINDOWS_VALID_WITHOUT_DOT_GIT_TWO = "..\\path\\to\\repo";
+    private static final String LOCAL_REPO_LOCATION_WINDOWS_VALID_WITHOUT_DOT_GIT_THREE = "file://path\\to\\repo";
+    private static final String LOCAL_REPO_LOCATION_WINDOWS_VALID_WITH_DOT_GIT_ONE = "path\\to\\repo\\.git";
+    private static final String LOCAL_REPO_LOCATION_WINDOWS_VALID_WITH_DOT_GIT_TWO = "file://path\\to\\repo\\.git";
+    private static final String LOCAL_REPO_LOCATION_WINDOWS_VALID_MIXED = "..\\path/to\\repo";
+
+    private static final String EXPECTED_REPO_NAME = "repo";
+    private static final String EXPECTED_ORGANIZATION = "path-to";
 
     @Test
     public void repoLocationParser_parseEmptyString_success() throws Exception {
         RepoLocation repoLocation = new RepoLocation("");
     }
 
+    @Test
+    public void repoLocationParser_parseLocalRepoLocation_success() throws Exception {
+        // local paths not containing ".git" should be valid
+        assertValidLocation(LOCAL_REPO_LOCATION_VALID_WITHOUT_DOT_GIT_ONE,
+                EXPECTED_REPO_NAME, EXPECTED_ORGANIZATION);
+        // relative pathing should be considered part of the 'organization' for differentiation
+        assertValidLocation(LOCAL_REPO_LOCATION_VALID_WITHOUT_DOT_GIT_TWO,
+                EXPECTED_REPO_NAME, "..-" + EXPECTED_ORGANIZATION);
+        // local file paths designated by the URL file:// ...  should be valid
+        assertValidLocation(LOCAL_REPO_LOCATION_VALID_WITHOUT_DOT_GIT_THREE,
+                EXPECTED_REPO_NAME, EXPECTED_ORGANIZATION);
+
+        // local paths containing ".git" should also be valid
+        assertValidLocation(LOCAL_REPO_LOCATION_VALID_WITH_DOT_GIT_ONE,
+                EXPECTED_REPO_NAME, EXPECTED_ORGANIZATION);
+        assertValidLocation(LOCAL_REPO_LOCATION_VALID_WITH_DOT_GIT_TWO,
+                EXPECTED_REPO_NAME, EXPECTED_ORGANIZATION);
+
+        // repeated tests but with windows file separators
+        assertValidLocation(LOCAL_REPO_LOCATION_WINDOWS_VALID_WITHOUT_DOT_GIT_ONE,
+                EXPECTED_REPO_NAME, EXPECTED_ORGANIZATION);
+        assertValidLocation(LOCAL_REPO_LOCATION_WINDOWS_VALID_WITHOUT_DOT_GIT_TWO,
+                EXPECTED_REPO_NAME, "..-" + EXPECTED_ORGANIZATION);
+        assertValidLocation(LOCAL_REPO_LOCATION_WINDOWS_VALID_WITHOUT_DOT_GIT_THREE,
+                EXPECTED_REPO_NAME, EXPECTED_ORGANIZATION);
+        assertValidLocation(LOCAL_REPO_LOCATION_WINDOWS_VALID_WITH_DOT_GIT_ONE,
+                EXPECTED_REPO_NAME, EXPECTED_ORGANIZATION);
+        assertValidLocation(LOCAL_REPO_LOCATION_WINDOWS_VALID_WITH_DOT_GIT_TWO,
+                EXPECTED_REPO_NAME, EXPECTED_ORGANIZATION);
+
+        assertValidLocation(LOCAL_REPO_LOCATION_WINDOWS_VALID_MIXED,
+                EXPECTED_REPO_NAME, "..-" + EXPECTED_ORGANIZATION);
+    }
+
+    @Test
+    public void repoLocation_validRemoteRepoUrl_success() throws Exception {
+        // valid url without specifying branch
+        assertValidLocation("https://github.com/reposense/testrepo-Beta.git",
+                "testrepo-Beta", "reposense");
+        assertValidLocation("https://github.com/reposense/testrepo-Delta.git",
+                "testrepo-Delta", "reposense");
+        assertValidLocation("https://gitlab.com/reposense/RepoSense.git",
+                "RepoSense", "reposense");
+        assertValidLocation("https://github.com/reposense.git",
+                "reposense", "");
+        // valid url to parse for obtaining repo and organization, just not a valid git clone target
+        assertValidLocation("https://github.com/reposense/.git",
+                "reposense", "");
+
+        // treated as valid but will be caught when git clone fails
+        assertValidLocation("https://github.com/reposense/testrepo-Beta/tree/add-config-json",
+                "add-config-json", "reposense-testrepo-Beta-tree");
+        assertValidLocation("https://github.com/reposense/testrepo-Beta.git/tree/add-config-json",
+                "add-config-json", "reposense-testrepo-Beta.git-tree");
+
+        // URLs without ".git" should be accepted as git clone works even without it
+        assertValidLocation("https://github.com/reposense",
+                "reposense", "");
+        assertValidLocation("https://github.com/reposense/RepoSense",
+                "RepoSense", "reposense");
+
+        // Test against other types of URL protocols that are valid for git clone
+        assertValidLocation("ssh://[user@]host.xz[:port]/path/to/repo.git/",
+                EXPECTED_REPO_NAME, EXPECTED_ORGANIZATION);
+        assertValidLocation("git://host.xz[:port]/path/to/repo.git",
+                EXPECTED_REPO_NAME, EXPECTED_ORGANIZATION);
+        assertValidLocation("https://host.xz[:port]/path/to/repo.git",
+                EXPECTED_REPO_NAME, EXPECTED_ORGANIZATION);
+
+        // Test against the conventional ssh protocol used for GitHub, e.g. git@github.com:reposense/RepoSense.git
+        assertValidLocation("[user@]host.xz:path/to/repo.git/",
+                EXPECTED_REPO_NAME, EXPECTED_ORGANIZATION);
+        assertValidLocation("git@github.com:reposense/RepoSense.git",
+                "RepoSense", "reposense");
+        assertValidLocation("user@host.xz:RepoSense.git",
+                "RepoSense", "");
+    }
+
+    /**
+     * Compares the information parsed by the RepoLocation model with the expected information
+     */
+    public void assertValidLocation(String rawLocation, String expectedRepoName,
+            String expectedOrganization) throws Exception {
+        RepoLocation repoLocation = new RepoLocation(rawLocation);
+        Assert.assertEquals(expectedRepoName, repoLocation.getRepoName());
+        Assert.assertEquals(expectedOrganization, repoLocation.getOrganization());
+    }
+
+    private void assertInvalidLocation(String rawLocation) {
+        AssertUtil.assertThrows(InvalidLocationException.class, () -> new RepoLocation(rawLocation));
+    }
 }

--- a/src/test/java/reposense/model/RepoLocationTest.java
+++ b/src/test/java/reposense/model/RepoLocationTest.java
@@ -7,57 +7,10 @@ import reposense.parser.InvalidLocationException;
 import reposense.util.AssertUtil;
 
 public class RepoLocationTest {
-    @Test
-    public void repoLocation_validRepoUrl_success() throws Exception {
-        // valid url without specifying branch
-        assertValidLocation("https://github.com/reposense/testrepo-Beta.git",
-                "testrepo-Beta", "reposense");
-        assertValidLocation("https://github.com/reposense/testrepo-Delta.git",
-                "testrepo-Delta", "reposense");
-    }
-
-    @Test
-    public void repoLocation_invalidRepoUrl_throwsInvalidLocationException() {
-        // ftp url should be rejected
-        assertInvalidLocation("ftp://github.com/reposense/testrepo-Delta.git");
-        // non GitHub url should rejected
-        assertInvalidLocation("https://gitlab.com/reposense/RepoSense.git");
-        // url without organisation name should be rejected
-        assertInvalidLocation("https://github.com/reposense.git");
-        // url without repo name should be rejected
-        assertInvalidLocation("https://github.com/reposense/.git");
-        assertInvalidLocation("https://github.com/reposense");
-        // url without a .git suffix should be rejected
-        assertInvalidLocation("https://github.com/reposense/RepoSensegit");
-        assertInvalidLocation("https://github.com/reposense/RepoSense-git");
-        assertInvalidLocation("https://github.com/reposense/RepoSense.gi");
-        assertInvalidLocation("https://github.com/reposense/RepoSense");
-    }
-
-    @Test
-    public void repoLocation_repoUrlWithASpecifiedBranch_throwsInvalidLocationException() {
-        // reject both repos with and without .git
-        assertInvalidLocation("https://github.com/reposense/testrepo-Beta/tree/add-config-json");
-        assertInvalidLocation("https://github.com/reposense/testrepo-Beta.git/tree/add-config-json");
-    }
 
     @Test
     public void repoLocationParser_parseEmptyString_success() throws Exception {
         RepoLocation repoLocation = new RepoLocation("");
     }
 
-
-    /**
-     * Compares the information parsed by the RepoLocation model with the expected information
-     */
-    public void assertValidLocation(String rawLocation, String expectedRepoName,
-            String expectedOrganization) throws Exception {
-        RepoLocation repoLocation = new RepoLocation(rawLocation);
-        Assert.assertEquals(repoLocation.getRepoName(), expectedRepoName);
-        Assert.assertEquals(repoLocation.getOrganization(), expectedOrganization);
-    }
-
-    private void assertInvalidLocation(String rawLocation) {
-        AssertUtil.assertThrows(InvalidLocationException.class, () -> new RepoLocation(rawLocation));
-    }
 }

--- a/src/test/java/reposense/model/RepoLocationTest.java
+++ b/src/test/java/reposense/model/RepoLocationTest.java
@@ -1,10 +1,6 @@
 package reposense.model;
 
-import org.junit.Assert;
 import org.junit.Test;
-
-import reposense.parser.InvalidLocationException;
-import reposense.util.AssertUtil;
 
 public class RepoLocationTest {
 

--- a/src/test/java/reposense/model/RepoLocationTest.java
+++ b/src/test/java/reposense/model/RepoLocationTest.java
@@ -2,6 +2,7 @@ package reposense.model;
 
 import org.junit.Assert;
 import org.junit.Test;
+
 import reposense.parser.InvalidLocationException;
 import reposense.util.AssertUtil;
 

--- a/src/test/java/reposense/parser/ArgsParserTest.java
+++ b/src/test/java/reposense/parser/ArgsParserTest.java
@@ -542,14 +542,6 @@ public class ArgsParserTest {
         Assert.assertEquals(repoAliasCliArguments, reposAliasCliArguments);
     }
 
-    @Test (expected = ParseException.class)
-    public void parse_noValidRepoLocation_throwsParseException() throws Exception {
-        String input = new InputBuilder().addRepos("https://githubaaaa.com/asdasdasdasd/RepoSense").build();
-        CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
-        Assert.assertTrue(cliArguments instanceof LocationsCliArguments);
-        RepoSense.getRepoConfigurations((LocationsCliArguments) cliArguments);
-    }
-
     @Test(expected = ParseException.class)
     public void absoluteConfigFolder_withoutRequiredConfigFiles_throwsParseException() throws Exception {
         Path absDirectory = PROJECT_DIRECTORY.getParent().toAbsolutePath();

--- a/src/test/java/reposense/parser/AuthorConfigParserTest.java
+++ b/src/test/java/reposense/parser/AuthorConfigParserTest.java
@@ -31,8 +31,6 @@ public class AuthorConfigParserTest {
             "AuthorConfigParserTest/authorconfig_commasAndDoubleQuotes_test.csv");
     private static final Path AUTHOR_CONFIG_MULTIPLE_EMAILS_FILE = loadResource(AuthorConfigParserTest.class,
             "AuthorConfigParserTest/authorconfig_multipleEmails_test.csv");
-    private static final Path AUTHOR_CONFIG_INVALID_LOCATION = loadResource(AuthorConfigParserTest.class,
-            "AuthorConfigParserTest/authorconfig_invalidLocation_test.csv");
     private static final Path AUTHOR_CONFIG_DIFFERENT_COLUMN_ORDER = loadResource(AuthorConfigParserTest.class,
             "AuthorConfigParserTest/authorconfig_differentColumnOrder_test.csv");
     private static final Path AUTHOR_CONFIG_MISSING_OPTIONAL_HEADER = loadResource(AuthorConfigParserTest.class,

--- a/src/test/java/reposense/parser/AuthorConfigParserTest.java
+++ b/src/test/java/reposense/parser/AuthorConfigParserTest.java
@@ -147,18 +147,6 @@ public class AuthorConfigParserTest {
     }
 
     @Test
-    public void authorConfig_invalidLocation_success() throws Exception {
-        AuthorConfigCsvParser authorConfigCsvParser = new AuthorConfigCsvParser(AUTHOR_CONFIG_INVALID_LOCATION);
-        List<AuthorConfiguration> configs = authorConfigCsvParser.parse();
-
-        Assert.assertEquals(1, configs.size());
-
-        AuthorConfiguration config = configs.get(0);
-
-        Assert.assertEquals(3, config.getAuthorList().size());
-    }
-
-    @Test
     public void authorConfig_differentColumnOrder_success() throws Exception {
         AuthorConfigCsvParser authorConfigCsvParser =
                 new AuthorConfigCsvParser(AUTHOR_CONFIG_DIFFERENT_COLUMN_ORDER);

--- a/src/test/java/reposense/parser/GroupConfigParserTest.java
+++ b/src/test/java/reposense/parser/GroupConfigParserTest.java
@@ -38,17 +38,6 @@ public class GroupConfigParserTest {
             new FileType("Test", Arrays.asList("src/test/**", "src/systest/**")));
 
     @Test
-    public void groupConfig_invalidLocation_success() throws Exception {
-        GroupConfigCsvParser groupConfigCsvParser = new GroupConfigCsvParser(GROUP_CONFIG_INVALID_LOCATION_FILE);
-        List<GroupConfiguration> groupConfigs = groupConfigCsvParser.parse();
-
-        Assert.assertEquals(1, groupConfigs.size());
-
-        GroupConfiguration actualConfig = groupConfigs.get(0);
-        Assert.assertEquals(2, actualConfig.getGroupsList().size());
-    }
-
-    @Test
     public void groupConfig_emptyLocation_success() throws Exception {
         GroupConfigCsvParser groupConfigCsvParser = new GroupConfigCsvParser(GROUP_CONFIG_EMPTY_LOCATION_FILE);
         List<GroupConfiguration> groupConfigs = groupConfigCsvParser.parse();

--- a/src/test/java/reposense/parser/GroupConfigParserTest.java
+++ b/src/test/java/reposense/parser/GroupConfigParserTest.java
@@ -18,8 +18,6 @@ public class GroupConfigParserTest {
             "GroupConfigParserTest/groupconfig_multipleLocation_test.csv");
     private static final Path GROUP_CONFIG_EMPTY_LOCATION_FILE = loadResource(GroupConfigParserTest.class,
             "GroupConfigParserTest/groupconfig_emptyLocation_test.csv");
-    private static final Path GROUP_CONFIG_INVALID_LOCATION_FILE = loadResource(GroupConfigParserTest.class,
-            "GroupConfigParserTest/groupconfig_invalidLocation_test.csv");
     private static final Path GROUP_CONFIG_DIFFERENT_COLUMN_ORDER_FILE = loadResource(GroupConfigParserTest.class,
             "GroupConfigParserTest/groupconfig_differentColumnOrder_test.csv");
     private static final Path GROUP_CONFIG_MISSING_OPTIONAL_HEADER_FILE = loadResource(GroupConfigParserTest.class,

--- a/src/test/java/reposense/parser/RepoConfigParserTest.java
+++ b/src/test/java/reposense/parser/RepoConfigParserTest.java
@@ -33,8 +33,6 @@ public class RepoConfigParserTest {
             "RepoConfigParserTest/repoconfig_overrideKeyword_test.csv");
     private static final Path REPO_CONFIG_REDUNDANT_LINES_FILE = loadResource(RepoConfigParserTest.class,
             "RepoConfigParserTest/require_trailing_whitespaces/repoconfig_redundantLines_test.csv");
-    private static final Path REPO_CONFIG_INVALID_LOCATION_FILE = loadResource(RepoConfigParserTest.class,
-            "RepoConfigParserTest/repoconfig_invalidLocation_test.csv");
     private static final Path REPO_CONFIG_UNRECOGNIZED_VALUES_FOR_YES_KEYWORD_HEADERS_FILE =
             loadResource(RepoConfigParserTest.class,
             "RepoConfigParserTest/repoconfig_unrecognizedValuesForYesKeywordHeaders_test.csv");

--- a/src/test/java/reposense/parser/RepoConfigParserTest.java
+++ b/src/test/java/reposense/parser/RepoConfigParserTest.java
@@ -297,14 +297,6 @@ public class RepoConfigParserTest {
     }
 
     @Test
-    public void repoConfig_withInvalidLocation_success() throws Exception {
-        RepoConfigCsvParser repoConfigCsvParser = new RepoConfigCsvParser(REPO_CONFIG_INVALID_LOCATION_FILE);
-        List<RepoConfiguration> configs = repoConfigCsvParser.parse();
-
-        Assert.assertEquals(2, configs.size());
-    }
-
-    @Test
     public void repoConfig_withUnrecognizedValuesForYesKeywordHeaders_valuesIgnored() throws Exception {
         RepoConfigCsvParser repoConfigCsvParser =
                 new RepoConfigCsvParser(REPO_CONFIG_UNRECOGNIZED_VALUES_FOR_YES_KEYWORD_HEADERS_FILE);

--- a/src/test/resources/AuthorConfigParserTest/authorconfig_invalidLocation_test.csv
+++ b/src/test/resources/AuthorConfigParserTest/authorconfig_invalidLocation_test.csv
@@ -1,7 +1,0 @@
-Repository's Location,Branch,Author's GitHub ID,Author's Emails,Author's Display Name,Author's Git Author Name,Ignore Glob List
-https://github.com/reposense/reposense.git,master,emer7,,GILBERT,emer7,
-https://github.com/parseexception/invalid.location,master,eugenepeh,,Eugene Peh,Eugene Peh,
-https://github.com/reposense/reposense.git,master,ongspxm,,SHUPENG,ongspxm,
-https://github.com/reposense/reposense.git,master,fzdy1914,,WANG CHAO,WANG CHAO,
-ftp://github.com/reposense/RepoSense.git,master,jamessspanggg,,James,James,
-

--- a/src/test/resources/GroupConfigParserTest/groupconfig_invalidLocation_test.csv
+++ b/src/test/resources/GroupConfigParserTest/groupconfig_invalidLocation_test.csv
@@ -1,5 +1,0 @@
-Repository's Location,Group Name,Globs
-https://github.com/reposense/testrepo-Beta.git,Code,**/*.java;**/*.py
-https://github.com/someCoy/invalidlocation,Main,**/*.py
-https://github.com/reposense/testrepo-Beta.git,Docs,docs/**
-ftp://github.com/reposense/testrepo-Beta.git,Code,**/*.java;**/*.py

--- a/src/test/resources/RepoConfigParserTest/repoconfig_invalidLocation_test.csv
+++ b/src/test/resources/RepoConfigParserTest/repoconfig_invalidLocation_test.csv
@@ -1,4 +1,0 @@
-Repository's Location,Branch,File formats,Ignore Glob List,Ignore standalone config,Ignore Commits List,Ignore Authors List,Shallow Cloning,Find Previous Authors
-https://github.com/reposense/testrepo-Beta.git,,,,,,,,
-https://github.com/reposense/testrepo-Delta.git,,,,,,,,
-ftp://github.com/reposense/testrepo-Delta.git,,,,,,,,


### PR DESCRIPTION
This PR shows the feasibility of such a change. The current changes pass existing test cases except those reliant on the existing location verification by `verifyLocation` in `RepoLocation`.

Changes:
- changed local repo detection logic to match the one used by git (source: scm.com/docs/git-clone#_git_urls)
- removed test cases reliant on failure of invalid location detection by `RepoLocation`

Additional steps needed:
- New test cases for valid repositories hosted by other URLs such as BitBucket
- New test cases for local repos given in the URL form (i.e. `file:///path/to/repo.git/`)
- More explicit error message/warning to user to inform them that cloning failed as `git` was unable to perform a clone on the specified location 